### PR TITLE
chore(auth): Align Kinde routes to blabout.com + clippy fixes + lockfile

### DIFF
--- a/backend/app.yaml
+++ b/backend/app.yaml
@@ -11,10 +11,10 @@ env_variables:
   RUST_LOG: info
   PORT: 8080
   DATABASE_URL: postgresql://postgres:password@localhost/blabout
-  KINDE_DOMAIN: https://aftuh.kinde.com
+  KINDE_DOMAIN: https://blabout.kinde.com
   KINDE_CLIENT_ID: 86cc8835a73840638345742c900e3265
   KINDE_CLIENT_SECRET: not_applicable_for_public_client
-  KINDE_REDIRECT_URI: https://blabout.com/auth/callback
+  KINDE_REDIRECT_URI: https://blabout.com
   OPENROUTER_API_KEY: your_openrouter_api_key
   GOOGLE_CLOUD_PROJECT_ID: your_gcp_project_id
 

--- a/backend/src/ai_service.rs
+++ b/backend/src/ai_service.rs
@@ -3,7 +3,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::time::Duration;
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 
 #[derive(Debug, Clone)]
 pub struct AiService {

--- a/backend/src/auth_paseto.rs
+++ b/backend/src/auth_paseto.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Duration, Utc};
 use ed25519_dalek::{Signature, SigningKey, VerifyingKey, Signer, Verifier};
 use serde::{Deserialize, Serialize};
-use serde_json::Value as JsonValue;
+use base64::Engine;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PasetoClaims {

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -1,14 +1,12 @@
 use anyhow::Result;
-use bb8::{Pool, PooledConnection};
+use bb8::Pool;
 use bb8_postgres::PostgresConnectionManager;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 use tokio_postgres::{NoTls, Row};
 use uuid::Uuid;
 
 pub type DbPool = Pool<PostgresConnectionManager<NoTls>>;
-pub type DbConnection = PooledConnection<'static, PostgresConnectionManager<NoTls>>;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct User {
@@ -97,6 +95,7 @@ pub async fn init_schema(pool: &DbPool) -> Result<()> {
     Ok(())
 }
 
+#[allow(dead_code)]
 impl User {
     pub async fn find_by_provider_id(pool: &DbPool, provider_id: &str) -> Result<Option<User>> {
         let conn = pool.get().await?;

--- a/deploy-to-cloud-run.sh
+++ b/deploy-to-cloud-run.sh
@@ -28,7 +28,7 @@ gcloud run services describe $SERVICE_NAME --region=$REGION --format='value(stat
 echo ""
 echo "🔧 To set environment variables for production:"
 echo "gcloud run services update $SERVICE_NAME --region=$REGION \\"
-echo "  --set-env-vars REACT_APP_KINDE_REDIRECT_URI=https://blabout.com/auth/callback,\\"
+echo "  --set-env-vars REACT_APP_KINDE_REDIRECT_URI=https://blabout.com,\\"
 echo "  REACT_APP_KINDE_POST_LOGOUT_REDIRECT_URL=https://blabout.com,\\"
 echo "  REACT_APP_KINDE_POST_LOGIN_REDIRECT_URL=https://blabout.com,\\"
 echo "  REACT_APP_API_BASE_URL=https://api.blabout.com"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -10,8 +10,8 @@
     "pack": "electron-builder --dir"
   },
   "devDependencies": {
-    "electron": "^25.0.0",
-    "electron-builder": "^24.0.0"
+    "electron": "^35.0.0",
+    "electron-builder": "^26.0.20"
   },
   "build": {
     "appId": "com.monorepo.desktop",

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -10,8 +10,10 @@ function createWindow() {
     width: 1200,
     height: 800,
     webPreferences: {
-      nodeIntegration: true,
-      contextIsolation: false,
+      // Hardened defaults for Electron ≥35 / Node 22
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, 'preload.js'),
     },
     icon: path.join(__dirname, '../public/icon.png'),
   });

--- a/desktop/src/preload.js
+++ b/desktop/src/preload.js
@@ -1,0 +1,8 @@
+const { contextBridge } = require('electron');
+
+// Expose a minimal, audited API surface to the renderer.
+// Add methods here as needed; avoid exposing Node primitives directly.
+contextBridge.exposeInMainWorld('desktopAPI', {
+  // example no-op; fill with safe IPC hooks when required
+  ping: () => 'pong',
+});

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,5 @@
 REACT_APP_KINDE_CLIENT_ID=86cc8835a73840638345742c900e3265
-REACT_APP_KINDE_DOMAIN=https://aftuh.kinde.com
+REACT_APP_KINDE_DOMAIN=https://blabout.kinde.com
 REACT_APP_API_BASE_URL=https://api.blabout.com
 REACT_APP_OPENROUTER_API_KEY=your_openrouter_api_key
 GOOGLE_CLOUD_PROJECT_ID=your_gcp_project_id

--- a/frontend/app.yaml
+++ b/frontend/app.yaml
@@ -5,7 +5,7 @@ service: frontend
 env_variables:
   NODE_ENV: production
   REACT_APP_KINDE_CLIENT_ID: 86cc8835a73840638345742c900e3265
-  REACT_APP_KINDE_DOMAIN: https://aftuh.kinde.com
+  REACT_APP_KINDE_DOMAIN: https://blabout.kinde.com
   REACT_APP_API_BASE_URL: https://api.blabout.com
   REACT_APP_OPENROUTER_API_KEY: your_openrouter_api_key
   REACT_APP_GCP_PROJECT_ID: your_gcp_project_id


### PR DESCRIPTION
- Kinde domain -> https://blabout.kinde.com; redirect/logout -> https://blabout.com\n- Backend clippy cleanup (unused imports/dead code, base64 Engine import)\n- Regenerate frontend/package-lock.json to keep npm ci in sync\n\nCI expected: clippy clean, npm ci lockfile clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Desktop app exposes a minimal, secure renderer API (preload bridge) with a test ping.

- Refactor
  - Hardened desktop security defaults (disabled Node integration, enabled context isolation).

- Chores
  - Updated authentication domain and redirect settings across backend, frontend, and deployment to the new Kinde domain/root redirect.
  - Upgraded desktop dependencies (Electron and build tooling).

- Tests
  - No changes.

- Documentation
  - Updated example environment to reflect the new authentication domain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->